### PR TITLE
Allow the snap to access package management folders (local and remote)

### DIFF
--- a/snapcraft.tpl.yaml
+++ b/snapcraft.tpl.yaml
@@ -24,6 +24,16 @@ parts:
     build-packages:
        - pkg-config
 
+plugs:
+  dot-local-share-typst:
+    interface: personal-files
+    write:
+    - $HOME/.local/share/typst
+  dot-cache-typst:
+    interface: personal-files
+    write:
+    - $HOME/.cache/typst
+
 apps:
   typst:
     command: "bin/typst"
@@ -32,3 +42,5 @@ apps:
       - network # retrieve packages
       - home    # read sources and write output
       - removable-media # read sources on media
+      - dot-local-share-typst # read/write ~/.local/share/typst
+      - dot-cache-typst # read/write ~/.cache/typst


### PR DESCRIPTION
Snap apps don't have access by default to hidden files, even to those in the user dir. Typst uses ~/.local/share/typst and ~/.cache/typst for package management and without access to those, local packages or previously downloaded packages can't be used.

The needed package locations are documented at https://github.com/typst/packages/tree/main

The proposed configuration is untested and may be incomplete (sorry, I'm just a snap user). Also, it may need further approval from snapcraft admins so the plugs can be automatically automounted for Typst. This permission should be requested, AFAICT, in the forum. The config and the approval proccess are documented in the personal-files interface documentation here: https://snapcraft.io/docs/personal-files-interface