### PR TITLE
ARM-64 builds, access to Typst package paths, and resolve font paths

### DIFF
--- a/.github/workflows/dispatch.yaml
+++ b/.github/workflows/dispatch.yaml
@@ -16,7 +16,15 @@ env:
 
 jobs:
   buildSnap:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - architecture: amd64
+            runner: ubuntu-latest
+          - architecture: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     if: ${{ env.does-run }}
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -6,16 +6,14 @@ repository. If we decide to offer this Snap permanently, they will be triggered
 by a Repository Dispatch from
 [Typst's main repository](https://github.com/typst/typst) instead.
 
-## Limitations
-Since this is an experimental release, there are some limitations:
+## Technical Notes
 
-- Only `amd64` is supported
-- Neither the `home` nor the `removable-media` interface autoconnect
+The snap is configured to use the real user home directory paths (via `SNAP_REAL_HOME`) for packages and fonts, rather than the sandboxed snap home directory. This allows Typst to access `~/.local/share/typst/packages` and `~/.cache/typst/packages` directly without requiring manual connection of the `personal-files` interfaces (`typst:dot-cache-typst` and `typst:dot-local-share-typst`).
+
+This means the snap works out-of-the-box with no additional configuration needed.
 
 ## Contributing
-Contributions are welcome, especially for adding more architectures and
-documentation. We expect `arm64` to be the most sought after `amd64`. Also let
-us know if you are or would be interested in using Typst as a Snap.
+Let us know if you are or would be interested in using Typst as a Snap.
 
 ## License
 This repository is licensed as Apache 2.0.

--- a/snapcraft.tpl.yaml
+++ b/snapcraft.tpl.yaml
@@ -1,5 +1,10 @@
 name: typst
 base: core22
+architectures:
+  - build-on: amd64
+    build-for: amd64
+  - build-on: arm64
+    build-for: arm64
 version: "<version>"
 summary: A new markup-based typesetting system that is powerful and easy to learn.
 description: |
@@ -29,14 +34,31 @@ parts:
     rust-features:
       - vendor-openssl
     build-packages:
-       - pkg-config
+      - pkg-config
 
 apps:
   typst:
     command: "bin/typst"
+    environment:
+      # Point Typst to real user directories for packages
+      # SNAP_REAL_HOME is the vanilla HOME before snapd remapping
+      TYPST_PACKAGE_PATH: $SNAP_REAL_HOME/.local/share/typst/packages
+      TYPST_PACKAGE_CACHE_PATH: $SNAP_REAL_HOME/.cache/typst/packages
+      # Typst font path is a list that should have the snap real home (~/.local/share/fonts) and the system fonts (which are already read by default)
+      TYPST_FONT_PATHS: $SNAP_REAL_HOME/.local/share/fonts:/usr/share/fonts
     plugs:
       - desktop # access host fonts
       - network # retrieve packages
-      - home    # read sources and write output
+      - home # read sources and write output
       - removable-media # read sources on media
       - network-bind # serve live HTML in watch mode
+
+plugs:
+  dot-local-share-typst:
+    interface: personal-files
+    read:
+      - $HOME/.local/share/typst
+  dot-cache-typst:
+    interface: personal-files
+    write:
+      - $HOME/.cache/typst


### PR DESCRIPTION
This solves:

- #2: Added interfaces and real snap home paths for proper resolution.
- #6: Added (again) via real snap home paths for `/usr/share/fonts`  and `~/.local/share/fonts`.
- and the `README`-wanted ARM support (you can check my fork's actions which tests on Ubuntu ARM/AMD both build and installation).

The current branch (main) modifies the actions for testing, so I'll just wait for review and approval to change the PR to the proper branch (unless it's possible by git to modify on merge the files (I don't really know, at last I'll just hard reset it to upstream with the template changes)).

Auto connecting is a bit weird, as yeah one needs to manually connect it (or request auto connection via the snap craft store) but setting the environments in the app kinda grants access to it without need to auto connect (as of my local tests).

**ARM testing was only tested via actions.**

> As a side note, you forgot to close #4 which was fixed by #3.